### PR TITLE
Fixed metrics showing on multiple rows

### DIFF
--- a/src/components/RegularWidget.vue
+++ b/src/components/RegularWidget.vue
@@ -237,6 +237,7 @@ div.logo {
   padding: 0.5rem !important;
   width: 33%;
   position: relative;
+  box-sizing: border-box;
 }
 
 .row {


### PR DESCRIPTION
## Purpose
Fixes visual bug where metrics were showing up as multiple rows instead of all on one row

closes: https://github.com/datacite/datacite/issues/1220

## Approach
Updated metric CS class to use `box-sizing: border-box` in order for the width to be properly calculated as 33% for each

![image](https://user-images.githubusercontent.com/43453735/205989146-b346e672-80ff-4b21-b62a-f71e4b66c774.png)


#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
